### PR TITLE
allow any major version of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 
     "require": {
         "php": ">=8.0",
-        "psr/log": "^3.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",


### PR DESCRIPTION
Many libraries out there only support psr/log 1.x or psr/log 2.x this makes this library compatible with those libraries, all unit tests pass with psr/log 1.1.4 installed